### PR TITLE
improve build system: clean; added all, install targets

### DIFF
--- a/CICADA_v1/Makefile
+++ b/CICADA_v1/Makefile
@@ -1,8 +1,7 @@
 .PHONY: clean
 
-CICADAModel_v1.so: myproject.o caloADModel_v1.o $(EMULATOR_EXTRA_LIBRARY)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $(EMULATOR_EXTRA_LIBRARY) -shared $^ -o $@
-	rm $^
+CICADAModel_v1.so: myproject.o caloADModel_v1.o
+	$(CXX) $(CXXFLAGS) $(LD_FLAGS) -shared $^ -o $@
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/CICADA_v2/Makefile
+++ b/CICADA_v2/Makefile
@@ -1,8 +1,7 @@
 .PHONY: clean
 
-CICADAModel_v2.so: myproject.o caloADModel_v2.o $(EMULATOR_EXTRA_LIBRARY)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $(EMULATOR_EXTRA_LIBRARY) -shared $^ -o $@
-	rm $^
+CICADAModel_v2.so: myproject.o caloADModel_v2.o
+	$(CXX) $(CXXFLAGS) $(LD_FLAGS) -shared $^ -o $@
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@


### PR DESCRIPTION
I have cleaned up the build system ( Makefile) and added standard `all, install` targets. 
- CICADA_v*/Makefile:
  - Make use of LD_FLAGS/INCLUDES flags. INCLUDES are not needed for linking
  - Do not delete generated objects files and specially $(EMULATOR_EXTRA_LIBRARY) which is not part of this repository
- Makefile:
  - added standard `all` and `install` targets
  - Use `hls4mlEmulatorExtras` from EMULATOR_EXTRAS if set otherwise fallback to local ../../hls4mlEmulatorExtras path
  - `install` to copy the generated shared libs in `lib64` directory
  - Do not export INCLUDES, LD_FLAGS, CXXFLAGS but explicitly pass these to sub-make