### PR TITLE
No need to explicitly check for PREFIX and EMULATOR_EXTRAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,7 @@
 CPP_STANDARD := c++17
 CXXFLAGS := -O3 -fPIC -std=$(CPP_STANDARD)
-
-ifeq ($(strip $(PREFIX)),)
 PREFIX:=.
-endif
-
-ifeq ($(strip $(EMULATOR_EXTRAS)),)
 EMULATOR_EXTRAS := ../../hls4mlEmulatorExtras
-endif
-
 AP_TYPES := $(EMULATOR_EXTRAS)/include/ap_types
 HLS_ROOT := ../../hls
 HLS4ML_INCLUDE := $(EMULATOR_EXTRAS)/include/hls4ml


### PR DESCRIPTION
Setting CICADA and EMULATOR_EXTRAS as env overrides the values when `make` is run, so there is no need to explicitly check if these are set or not